### PR TITLE
Feat/parent child index

### DIFF
--- a/app/controllers/gym_rope_routes_controller.rb
+++ b/app/controllers/gym_rope_routes_controller.rb
@@ -1,0 +1,6 @@
+class GymRopeRoutesController < ApplicationController
+  def index
+    @gym = Gym.find(params[:gym_id])
+    @rope_routes = @gym.rope_routes
+  end
+end

--- a/app/views/gym_rope_routes/index.html.erb
+++ b/app/views/gym_rope_routes/index.html.erb
@@ -1,0 +1,11 @@
+<h1>Rope Routes at <%= @gym.name %> in <%= @gym.location %></h1>
+  <% @rope_routes.each do |route| %>
+    <h3>Grade: <%= route.grade %>, <%= route.color %></h3>
+    <p>Route ID: <%= route.id %></p>
+    <p>Top Rope: <%= route.top_rope %></p>
+    <p>Lead: <%= route.lead %></p>
+    <p>Height (in feet): <%= route.height %></p>
+    <p>Created: <%= route.created_at %></p>
+    <p>Updated: <%= route.updated_at %></p>
+    <p>Gym ID: <%= route.gym_id %></p>
+  <% end %>

--- a/app/views/rope_routes/index.html.erb
+++ b/app/views/rope_routes/index.html.erb
@@ -3,9 +3,9 @@
     <h3>Route ID: <%= route.id %></h2>
     <p>Grade: <%= route.grade %></p>
     <p>Color: <%= route.color %></p>
-    <p>Top Rope?: <%= route.top_rope %></p>
+    <p>Top Rope: <%= route.top_rope %></p>
     <p>Lead: <%= route.lead %></p>
     <p>Height (in feet): <%= route.height %></p>
     <p>Created: <%= route.created_at %></p>
     <p>Updated: <%= route.updated_at %></p>
-  <% end %>  
+  <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
 
   get '/rope_routes', to: 'rope_routes#index'
   get '/rope_routes/:id', to: 'rope_routes#show'
+  get '/gym/:gym_id/rope_routes', to: 'gym_rope_routes#index'
 end

--- a/spec/features/gyms/rope_routes/index_spec.rb
+++ b/spec/features/gyms/rope_routes/index_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-RSpec.describe 'rope_routes#show', type: :feature do
+RSpec.describe "Parent-Child index", type: :feature do
 
-  # User Story 4, Child Show
+  # User Story 5, Parent Children Index
   #
   # As a visitor
-  # When I visit '/child_table_name/:id'
-  # Then I see the child with that id including the child's attributes:
-  it 'displays a rope route from an ID and displays attributes' do
+  # When I visit '/parents/:parent_id/child_table_name'
+  # Then I see each Child that is associated with that Parent with each Child's attributes:
+  it "associates the child table to the parent ID" do
     gym_1 = Gym.create!(name: "Movement Englewood", location: "Englewood, CO", has_rope: true, square_feet: 175000)
     gym_2 = Gym.create!(name: "Movement Boulder", location: "Boulder, CO", has_rope: true, square_feet: 22000)
     rope_1 = gym_1.rope_routes.create!(grade: '5.9', color: 'Green', top_rope: true, lead: false, height: 33)
@@ -15,7 +15,7 @@ RSpec.describe 'rope_routes#show', type: :feature do
     rope_3 = gym_2.rope_routes.create!(grade: '5.10a', color: 'White', top_rope: true, lead: true, height: 33)
     rope_4 = gym_2.rope_routes.create!(grade: '5.11', color: 'White', top_rope: true, lead: true, height: 38)
 
-    visit "/rope_routes/#{rope_1.id}"
+    visit "/gym/#{gym_1.id}/rope_routes"
     # save_and_open_page
 
     expect(page).to have_content(rope_1.id)

--- a/spec/features/gyms/rope_routes/index_spec.rb
+++ b/spec/features/gyms/rope_routes/index_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe "Parent-Child index", type: :feature do
     rope_1 = gym_1.rope_routes.create!(grade: '5.9', color: 'Green', top_rope: true, lead: false, height: 33)
     rope_2 = gym_1.rope_routes.create!(grade: '5.11', color: 'Blue', top_rope: false, lead: true, height: 45)
     rope_3 = gym_2.rope_routes.create!(grade: '5.10a', color: 'White', top_rope: true, lead: true, height: 33)
-    rope_4 = gym_2.rope_routes.create!(grade: '5.11', color: 'White', top_rope: true, lead: true, height: 38)
+    rope_4 = gym_2.rope_routes.create!(grade: '5.8', color: 'White', top_rope: true, lead: true, height: 38)
 
     visit "/gym/#{gym_1.id}/rope_routes"
-    # save_and_open_page
+    save_and_open_page
 
     expect(page).to have_content(rope_1.id)
     expect(page).to have_content(rope_1.grade)
@@ -27,7 +27,9 @@ RSpec.describe "Parent-Child index", type: :feature do
     expect(page).to have_content(rope_1.created_at)
     expect(page).to have_content(rope_1.updated_at)
 
-    expect(page).to_not have_content(rope_2.grade)
+    expect(page).to have_content(rope_2.id)
+    expect(page).to have_content(rope_2.grade)
+
     expect(page).to_not have_content(rope_3.grade)
     expect(page).to_not have_content(rope_4.grade)
   end


### PR DESCRIPTION
Completes User Story 5; associates the Parent-Child index by allowing a query of every available rope route (the child) within a respective gym (the parent).